### PR TITLE
CC-55 Split public and backoffice API endpoints

### DIFF
--- a/src/main/java/pt/ua/deti/tqs/backend/controllers/ReservationController.java
+++ b/src/main/java/pt/ua/deti/tqs/backend/controllers/ReservationController.java
@@ -12,7 +12,7 @@ import pt.ua.deti.tqs.backend.helpers.Currency;
 import pt.ua.deti.tqs.backend.services.ReservationService;
 
 @RestController
-@RequestMapping("public/reservation")
+@RequestMapping("api/public/reservation")
 @Tag(name = "Reservation")
 @AllArgsConstructor
 public class ReservationController {

--- a/src/main/java/pt/ua/deti/tqs/backend/controllers/ReservationController.java
+++ b/src/main/java/pt/ua/deti/tqs/backend/controllers/ReservationController.java
@@ -11,10 +11,8 @@ import pt.ua.deti.tqs.backend.entities.Reservation;
 import pt.ua.deti.tqs.backend.helpers.Currency;
 import pt.ua.deti.tqs.backend.services.ReservationService;
 
-import java.util.List;
-
 @RestController
-@RequestMapping("api/reservation")
+@RequestMapping("public/reservation")
 @Tag(name = "Reservation")
 @AllArgsConstructor
 public class ReservationController {
@@ -30,14 +28,6 @@ public class ReservationController {
         return new ResponseEntity<>(created, status);
     }
 
-    @GetMapping
-    @Operation(summary = "Get all reservations")
-    public ResponseEntity<List<Reservation>> getReservations(
-            @RequestParam(required = false) @Parameter(name = "Currency", example = "EUR") Currency currency
-    ) {
-        return new ResponseEntity<>(reservationService.getAllReservations(currency), HttpStatus.OK);
-    }
-
     @GetMapping("{id}")
     @Operation(summary = "Get a reservation")
     public ResponseEntity<Reservation> getReservation(
@@ -46,18 +36,6 @@ public class ReservationController {
         Reservation reservation = reservationService.getReservation(id, currency);
         HttpStatus status = reservation != null ? HttpStatus.OK : HttpStatus.NOT_FOUND;
         return new ResponseEntity<>(reservation, status);
-    }
-
-    @PutMapping("{id}")
-    @Operation(summary = "Update a reservation")
-    public ResponseEntity<Reservation> updateReservation(
-            @PathVariable @Parameter(name = "Reservation ID", example = "1") Long id,
-            @RequestBody Reservation reservation,
-            @RequestParam(required = false) @Parameter(name = "Currency", example = "EUR") Currency currency) {
-        reservation.setId(id);
-        Reservation updated = reservationService.updateReservation(reservation, currency);
-        HttpStatus status = updated != null ? HttpStatus.OK : HttpStatus.NOT_FOUND;
-        return new ResponseEntity<>(updated, status);
     }
 
     @DeleteMapping("{id}")

--- a/src/main/java/pt/ua/deti/tqs/backend/controllers/TripController.java
+++ b/src/main/java/pt/ua/deti/tqs/backend/controllers/TripController.java
@@ -7,10 +7,8 @@ import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import pt.ua.deti.tqs.backend.entities.Reservation;
 import pt.ua.deti.tqs.backend.entities.Trip;
 import pt.ua.deti.tqs.backend.helpers.Currency;
-import pt.ua.deti.tqs.backend.services.ReservationService;
 import pt.ua.deti.tqs.backend.services.TripService;
 import pt.ua.deti.tqs.backend.specifications.trip.TripSearchParameters;
 
@@ -18,18 +16,11 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
-@RequestMapping("api/trip")
+@RequestMapping("public/trip")
 @Tag(name = "Trip")
 @AllArgsConstructor
 public class TripController {
     private final TripService tripService;
-    private final ReservationService reservationService;
-
-    @PostMapping
-    @Operation(summary = "Create a new trip")
-    public ResponseEntity<Trip> createTrip(@RequestBody Trip trip) {
-        return new ResponseEntity<>(tripService.createTrip(trip), HttpStatus.CREATED);
-    }
 
     @GetMapping
     @Operation(summary = "Get trips")
@@ -53,34 +44,5 @@ public class TripController {
         Trip trip = tripService.getTrip(id, currency);
         HttpStatus status = trip != null ? HttpStatus.OK : HttpStatus.NOT_FOUND;
         return new ResponseEntity<>(trip, status);
-    }
-
-    @GetMapping("{id}/reservations")
-    @Operation(summary = "Get all reservations of a trip")
-    public ResponseEntity<List<Reservation>> getReservationsByTripId(
-            @PathVariable @Parameter(name = "Trip ID", example = "1") Long id,
-            @RequestParam(required = false) @Parameter(name = "Currency", example = "EUR") Currency currency) {
-        List<Reservation> reservations = reservationService.getReservationsByTripId(id, currency);
-        HttpStatus status = !reservations.isEmpty() ? HttpStatus.OK : HttpStatus.NOT_FOUND;
-        return new ResponseEntity<>(reservations, status);
-    }
-
-    @PutMapping("{id}")
-    @Operation(summary = "Update a trip")
-    public ResponseEntity<Trip> updateTrip(
-            @PathVariable @Parameter(name = "Trip ID", example = "1") Long id,
-            @RequestBody Trip trip) {
-        trip.setId(id);
-        Trip updated = tripService.updateTrip(trip);
-        HttpStatus status = updated != null ? HttpStatus.OK : HttpStatus.NOT_FOUND;
-        return new ResponseEntity<>(updated, status);
-    }
-
-    @DeleteMapping("{id}")
-    @Operation(summary = "Delete a trip")
-    public ResponseEntity<Void> deleteTrip(
-            @PathVariable @Parameter(name = "Trip ID", example = "1") Long id) {
-        tripService.deleteTrip(id);
-        return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/pt/ua/deti/tqs/backend/controllers/TripController.java
+++ b/src/main/java/pt/ua/deti/tqs/backend/controllers/TripController.java
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
-@RequestMapping("public/trip")
+@RequestMapping("api/public/trip")
 @Tag(name = "Trip")
 @AllArgsConstructor
 public class TripController {

--- a/src/main/java/pt/ua/deti/tqs/backend/controllers/UserController.java
+++ b/src/main/java/pt/ua/deti/tqs/backend/controllers/UserController.java
@@ -16,7 +16,7 @@ import pt.ua.deti.tqs.backend.services.UserService;
 import java.util.List;
 
 @RestController
-@RequestMapping("public/user")
+@RequestMapping("api/public/user")
 @Tag(name = "User")
 @AllArgsConstructor
 public class UserController {

--- a/src/main/java/pt/ua/deti/tqs/backend/controllers/UserController.java
+++ b/src/main/java/pt/ua/deti/tqs/backend/controllers/UserController.java
@@ -16,7 +16,7 @@ import pt.ua.deti.tqs.backend.services.UserService;
 import java.util.List;
 
 @RestController
-@RequestMapping("api/user")
+@RequestMapping("public/user")
 @Tag(name = "User")
 @AllArgsConstructor
 public class UserController {

--- a/src/main/java/pt/ua/deti/tqs/backend/controllers/backoffice/BusController.java
+++ b/src/main/java/pt/ua/deti/tqs/backend/controllers/backoffice/BusController.java
@@ -13,7 +13,7 @@ import pt.ua.deti.tqs.backend.services.BusService;
 import java.util.List;
 
 @RestController
-@RequestMapping("backoffice/bus")
+@RequestMapping("api/backoffice/bus")
 @Tag(name = "Bus")
 @AllArgsConstructor
 public class BusController {

--- a/src/main/java/pt/ua/deti/tqs/backend/controllers/backoffice/BusController.java
+++ b/src/main/java/pt/ua/deti/tqs/backend/controllers/backoffice/BusController.java
@@ -1,4 +1,4 @@
-package pt.ua.deti.tqs.backend.controllers;
+package pt.ua.deti.tqs.backend.controllers.backoffice;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -13,7 +13,7 @@ import pt.ua.deti.tqs.backend.services.BusService;
 import java.util.List;
 
 @RestController
-@RequestMapping("api/bus")
+@RequestMapping("backoffice/bus")
 @Tag(name = "Bus")
 @AllArgsConstructor
 public class BusController {

--- a/src/main/java/pt/ua/deti/tqs/backend/controllers/backoffice/CityController.java
+++ b/src/main/java/pt/ua/deti/tqs/backend/controllers/backoffice/CityController.java
@@ -14,7 +14,7 @@ import pt.ua.deti.tqs.backend.services.CityService;
 import java.util.List;
 
 @RestController
-@RequestMapping("backoffice/city")
+@RequestMapping("api/backoffice/city")
 @Tag(name = "City")
 @AllArgsConstructor
 public class CityController {

--- a/src/main/java/pt/ua/deti/tqs/backend/controllers/backoffice/CityController.java
+++ b/src/main/java/pt/ua/deti/tqs/backend/controllers/backoffice/CityController.java
@@ -1,4 +1,4 @@
-package pt.ua.deti.tqs.backend.controllers;
+package pt.ua.deti.tqs.backend.controllers.backoffice;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -14,7 +14,7 @@ import pt.ua.deti.tqs.backend.services.CityService;
 import java.util.List;
 
 @RestController
-@RequestMapping("api/city")
+@RequestMapping("backoffice/city")
 @Tag(name = "City")
 @AllArgsConstructor
 public class CityController {

--- a/src/main/java/pt/ua/deti/tqs/backend/controllers/backoffice/ReservationBackofficeController.java
+++ b/src/main/java/pt/ua/deti/tqs/backend/controllers/backoffice/ReservationBackofficeController.java
@@ -14,7 +14,7 @@ import pt.ua.deti.tqs.backend.services.ReservationService;
 import java.util.List;
 
 @RestController
-@RequestMapping("backoffice/reservation")
+@RequestMapping("api/backoffice/reservation")
 @Tag(name = "Reservation")
 @AllArgsConstructor
 public class ReservationBackofficeController {

--- a/src/main/java/pt/ua/deti/tqs/backend/controllers/backoffice/ReservationBackofficeController.java
+++ b/src/main/java/pt/ua/deti/tqs/backend/controllers/backoffice/ReservationBackofficeController.java
@@ -1,0 +1,42 @@
+package pt.ua.deti.tqs.backend.controllers.backoffice;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import pt.ua.deti.tqs.backend.entities.Reservation;
+import pt.ua.deti.tqs.backend.helpers.Currency;
+import pt.ua.deti.tqs.backend.services.ReservationService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("backoffice/reservation")
+@Tag(name = "Reservation")
+@AllArgsConstructor
+public class ReservationBackofficeController {
+    private final ReservationService reservationService;
+
+    @GetMapping
+    @Operation(summary = "Get all reservations")
+    public ResponseEntity<List<Reservation>> getReservations(
+            @RequestParam(required = false) @Parameter(name = "Currency", example = "EUR") Currency currency
+    ) {
+        return new ResponseEntity<>(reservationService.getAllReservations(currency), HttpStatus.OK);
+    }
+
+    @PutMapping("{id}")
+    @Operation(summary = "Update a reservation")
+    public ResponseEntity<Reservation> updateReservation(
+            @PathVariable @Parameter(name = "Reservation ID", example = "1") Long id,
+            @RequestBody Reservation reservation,
+            @RequestParam(required = false) @Parameter(name = "Currency", example = "EUR") Currency currency) {
+        reservation.setId(id);
+        Reservation updated = reservationService.updateReservation(reservation, currency);
+        HttpStatus status = updated != null ? HttpStatus.OK : HttpStatus.NOT_FOUND;
+        return new ResponseEntity<>(updated, status);
+    }
+}

--- a/src/main/java/pt/ua/deti/tqs/backend/controllers/backoffice/StatsController.java
+++ b/src/main/java/pt/ua/deti/tqs/backend/controllers/backoffice/StatsController.java
@@ -1,4 +1,4 @@
-package pt.ua.deti.tqs.backend.controllers;
+package pt.ua.deti.tqs.backend.controllers.backoffice;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -12,13 +12,13 @@ import pt.ua.deti.tqs.backend.entities.Stats;
 import pt.ua.deti.tqs.backend.services.StatsService;
 
 @RestController
-@RequestMapping("api/stats")
+@RequestMapping("backoffice/stats")
 @Tag(name = "Stats")
 @AllArgsConstructor
 public class StatsController {
     private final StatsService statsService;
 
-    @GetMapping()
+    @GetMapping
     @Operation(summary = "Get stats")
     public ResponseEntity<Stats> getStats() {
         int totalRequests = statsService.getTotalRequests();

--- a/src/main/java/pt/ua/deti/tqs/backend/controllers/backoffice/StatsController.java
+++ b/src/main/java/pt/ua/deti/tqs/backend/controllers/backoffice/StatsController.java
@@ -12,7 +12,7 @@ import pt.ua.deti.tqs.backend.entities.Stats;
 import pt.ua.deti.tqs.backend.services.StatsService;
 
 @RestController
-@RequestMapping("backoffice/stats")
+@RequestMapping("api/backoffice/stats")
 @Tag(name = "Stats")
 @AllArgsConstructor
 public class StatsController {

--- a/src/main/java/pt/ua/deti/tqs/backend/controllers/backoffice/TripBackofficeController.java
+++ b/src/main/java/pt/ua/deti/tqs/backend/controllers/backoffice/TripBackofficeController.java
@@ -1,0 +1,62 @@
+package pt.ua.deti.tqs.backend.controllers.backoffice;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import pt.ua.deti.tqs.backend.entities.Reservation;
+import pt.ua.deti.tqs.backend.entities.Trip;
+import pt.ua.deti.tqs.backend.helpers.Currency;
+import pt.ua.deti.tqs.backend.services.ReservationService;
+import pt.ua.deti.tqs.backend.services.TripService;
+import pt.ua.deti.tqs.backend.specifications.trip.TripSearchParameters;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RestController
+@RequestMapping("backoffice/trip")
+@Tag(name = "Trip")
+@AllArgsConstructor
+public class TripBackofficeController {
+    private final TripService tripService;
+    private final ReservationService reservationService;
+
+    @PostMapping
+    @Operation(summary = "Create a new trip")
+    public ResponseEntity<Trip> createTrip(@RequestBody Trip trip) {
+        return new ResponseEntity<>(tripService.createTrip(trip), HttpStatus.CREATED);
+    }
+
+    @GetMapping("{id}/reservations")
+    @Operation(summary = "Get all reservations of a trip")
+    public ResponseEntity<List<Reservation>> getReservationsByTripId(
+            @PathVariable @Parameter(name = "Trip ID", example = "1") Long id,
+            @RequestParam(required = false) @Parameter(name = "Currency", example = "EUR") Currency currency) {
+        List<Reservation> reservations = reservationService.getReservationsByTripId(id, currency);
+        HttpStatus status = !reservations.isEmpty() ? HttpStatus.OK : HttpStatus.NOT_FOUND;
+        return new ResponseEntity<>(reservations, status);
+    }
+
+    @PutMapping("{id}")
+    @Operation(summary = "Update a trip")
+    public ResponseEntity<Trip> updateTrip(
+            @PathVariable @Parameter(name = "Trip ID", example = "1") Long id,
+            @RequestBody Trip trip) {
+        trip.setId(id);
+        Trip updated = tripService.updateTrip(trip);
+        HttpStatus status = updated != null ? HttpStatus.OK : HttpStatus.NOT_FOUND;
+        return new ResponseEntity<>(updated, status);
+    }
+
+    @DeleteMapping("{id}")
+    @Operation(summary = "Delete a trip")
+    public ResponseEntity<Void> deleteTrip(
+            @PathVariable @Parameter(name = "Trip ID", example = "1") Long id) {
+        tripService.deleteTrip(id);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}

--- a/src/main/java/pt/ua/deti/tqs/backend/controllers/backoffice/TripBackofficeController.java
+++ b/src/main/java/pt/ua/deti/tqs/backend/controllers/backoffice/TripBackofficeController.java
@@ -12,13 +12,11 @@ import pt.ua.deti.tqs.backend.entities.Trip;
 import pt.ua.deti.tqs.backend.helpers.Currency;
 import pt.ua.deti.tqs.backend.services.ReservationService;
 import pt.ua.deti.tqs.backend.services.TripService;
-import pt.ua.deti.tqs.backend.specifications.trip.TripSearchParameters;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
-@RequestMapping("backoffice/trip")
+@RequestMapping("api/backoffice/trip")
 @Tag(name = "Trip")
 @AllArgsConstructor
 public class TripBackofficeController {

--- a/src/test/java/pt/ua/deti/tqs/backend/controllers/BusControllerTest.java
+++ b/src/test/java/pt/ua/deti/tqs/backend/controllers/BusControllerTest.java
@@ -37,7 +37,7 @@ class BusControllerTest {
         when(service.createBus(Mockito.any())).thenReturn(bus);
 
         RestAssuredMockMvc.given().mockMvc(mockMvc).contentType(ContentType.JSON).body(bus)
-                          .when().post("/api/bus")
+                          .when().post("/api/backoffice/bus")
                           .then().statusCode(HttpStatus.CREATED.value())
                           .body("capacity", is(50));
 
@@ -59,7 +59,7 @@ class BusControllerTest {
         when(service.getAllBuses()).thenReturn(Arrays.asList(bus1, bus2, bus3));
 
         RestAssuredMockMvc.given().mockMvc(mockMvc)
-                          .when().get("/api/bus")
+                          .when().get("/api/backoffice/bus")
                           .then().statusCode(HttpStatus.OK.value())
                           .body("$", hasSize(3))
                           .body("[0].capacity", is(50))
@@ -78,7 +78,7 @@ class BusControllerTest {
         when(service.getBus(1L)).thenReturn(bus);
 
         RestAssuredMockMvc.given().mockMvc(mockMvc)
-                          .when().get("/api/bus/1")
+                          .when().get("/api/backoffice/bus/1")
                           .then().statusCode(HttpStatus.OK.value())
                           .body("capacity", is(50));
 
@@ -90,7 +90,7 @@ class BusControllerTest {
         when(service.getBus(1L)).thenReturn(null);
 
         RestAssuredMockMvc.given().mockMvc(mockMvc)
-                          .when().get("/api/bus/1")
+                          .when().get("/api/backoffice/bus/1")
                           .then().statusCode(HttpStatus.NOT_FOUND.value());
 
         verify(service, times(1)).getBus(1L);
@@ -104,7 +104,7 @@ class BusControllerTest {
         when(service.updateBus(Mockito.any(Bus.class))).then(returnsFirstArg());
 
         RestAssuredMockMvc.given().mockMvc(mockMvc).contentType(ContentType.JSON).body(bus)
-                          .when().put("/api/bus/1")
+                          .when().put("/api/backoffice/bus/1")
                           .then().statusCode(HttpStatus.OK.value())
                           .body("capacity", is(50));
 
@@ -114,7 +114,7 @@ class BusControllerTest {
     @Test
     void whenDeleteBusById_thenDeleteBus() {
         RestAssuredMockMvc.given().mockMvc(mockMvc)
-                          .when().delete("/api/bus/1")
+                          .when().delete("/api/backoffice/bus/1")
                           .then().statusCode(HttpStatus.OK.value());
 
         verify(service, times(1)).deleteBus(1L);

--- a/src/test/java/pt/ua/deti/tqs/backend/controllers/BusControllerTest.java
+++ b/src/test/java/pt/ua/deti/tqs/backend/controllers/BusControllerTest.java
@@ -2,7 +2,6 @@ package pt.ua.deti.tqs.backend.controllers;
 
 import io.restassured.http.ContentType;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,6 +9,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.web.servlet.MockMvc;
+import pt.ua.deti.tqs.backend.controllers.backoffice.BusController;
 import pt.ua.deti.tqs.backend.entities.Bus;
 import pt.ua.deti.tqs.backend.services.BusService;
 

--- a/src/test/java/pt/ua/deti/tqs/backend/controllers/CityControllerTest.java
+++ b/src/test/java/pt/ua/deti/tqs/backend/controllers/CityControllerTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import pt.ua.deti.tqs.backend.controllers.backoffice.CityController;
 import pt.ua.deti.tqs.backend.entities.City;
 import pt.ua.deti.tqs.backend.services.CityService;
 

--- a/src/test/java/pt/ua/deti/tqs/backend/controllers/CityControllerTest.java
+++ b/src/test/java/pt/ua/deti/tqs/backend/controllers/CityControllerTest.java
@@ -38,7 +38,7 @@ class CityControllerTest {
         when(service.createCity(Mockito.any())).thenReturn(city);
 
         RestAssuredMockMvc.given().mockMvc(mockMvc).contentType(MediaType.APPLICATION_JSON).body(city)
-                          .when().post("/api/city")
+                          .when().post("/api/backoffice/city")
                           .then().statusCode(HttpStatus.CREATED.value())
                           .body("name", is("Aveiro"));
 
@@ -60,7 +60,7 @@ class CityControllerTest {
         when(service.getAllCities()).thenReturn(Arrays.asList(city1, city2, city3));
 
         RestAssuredMockMvc.given().mockMvc(mockMvc)
-                          .when().get("/api/city")
+                          .when().get("/api/backoffice/city")
                           .then().statusCode(HttpStatus.OK.value())
                           .body("$", hasSize(3))
                           .body("[0].name", is("Aveiro"))
@@ -79,7 +79,7 @@ class CityControllerTest {
         when(service.getCity(1L)).thenReturn(city);
 
         RestAssuredMockMvc.given().mockMvc(mockMvc)
-                          .when().get("/api/city/1")
+                          .when().get("/api/backoffice/city/1")
                           .then().statusCode(HttpStatus.OK.value())
                           .body("name", is("Aveiro"));
 
@@ -95,7 +95,7 @@ class CityControllerTest {
         when(service.getCitiesByName("Aveiro")).thenReturn(List.of(city));
 
         RestAssuredMockMvc.given().mockMvc(mockMvc)
-                          .when().get("/api/city?name=Aveiro")
+                          .when().get("/api/backoffice/city?name=Aveiro")
                           .then().statusCode(HttpStatus.OK.value())
                           .body("[0].name", is("Aveiro"));
 
@@ -107,7 +107,7 @@ class CityControllerTest {
         when(service.getCity(1L)).thenReturn(null);
 
         RestAssuredMockMvc.given().mockMvc(mockMvc)
-                          .when().get("/api/city/1")
+                          .when().get("/api/backoffice/city/1")
                           .then().statusCode(HttpStatus.NOT_FOUND.value());
 
         verify(service, times(1)).getCity(1L);
@@ -122,7 +122,7 @@ class CityControllerTest {
         when(service.updateCity(Mockito.any(City.class))).then(returnsFirstArg());
 
         RestAssuredMockMvc.given().mockMvc(mockMvc).contentType(MediaType.APPLICATION_JSON).body(city)
-                          .when().put("/api/city/1")
+                          .when().put("/api/backoffice/city/1")
                           .then().statusCode(HttpStatus.OK.value())
                           .body("name", is("Aveiro"));
 
@@ -132,7 +132,7 @@ class CityControllerTest {
     @Test
     void whenDeleteCity_thenDeleteCity() {
         RestAssuredMockMvc.given().mockMvc(mockMvc)
-                          .when().delete("/api/city/1")
+                          .when().delete("/api/backoffice/city/1")
                           .then().statusCode(HttpStatus.OK.value());
 
         verify(service, times(1)).deleteCity(1L);

--- a/src/test/java/pt/ua/deti/tqs/backend/controllers/ReservationControllerTest.java
+++ b/src/test/java/pt/ua/deti/tqs/backend/controllers/ReservationControllerTest.java
@@ -20,7 +20,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.*;
 
-@WebMvcTest(ReservationBackofficeController.class)
+@WebMvcTest({ReservationBackofficeController.class, ReservationController.class})
 class ReservationControllerTest {
     @Autowired
     private MockMvc mockMvc;
@@ -46,7 +46,7 @@ class ReservationControllerTest {
         when(service.createReservation(Mockito.any(), eq(null))).thenReturn(reservation);
 
         RestAssuredMockMvc.given().mockMvc(mockMvc).contentType(MediaType.APPLICATION_JSON).body(reservation)
-                          .when().post("/api/reservation")
+                          .when().post("/api/public/reservation")
                           .then().statusCode(201)
                           .body("seats", is(2))
                           .body("price", is(10.0F))
@@ -88,7 +88,7 @@ class ReservationControllerTest {
         when(service.getAllReservations(null)).thenReturn(Arrays.asList(reservation1, reservation2, reservation3));
 
         RestAssuredMockMvc.given().mockMvc(mockMvc)
-                          .when().get("/api/reservation")
+                          .when().get("/api/backoffice/reservation")
                           .then().statusCode(200)
                           .body("$", hasSize(3))
                           .body("[0].seats", is(2))
@@ -125,7 +125,7 @@ class ReservationControllerTest {
         when(service.getReservation(1L, null)).thenReturn(reservation);
 
         RestAssuredMockMvc.given().mockMvc(mockMvc)
-                          .when().get("/api/reservation/1")
+                          .when().get("/api/public/reservation/1")
                           .then().statusCode(200)
                           .body("seats", is(2))
                           .body("price", is(10.0f))
@@ -140,7 +140,7 @@ class ReservationControllerTest {
         when(service.getReservation(1L, null)).thenReturn(null);
 
         RestAssuredMockMvc.given().mockMvc(mockMvc)
-                          .when().get("/api/reservation/1")
+                          .when().get("/api/public/reservation/1")
                           .then().statusCode(404);
 
         verify(service, times(1)).getReservation(1L, null);
@@ -164,7 +164,7 @@ class ReservationControllerTest {
         when(service.updateReservation(Mockito.any(), Mockito.eq(null))).thenReturn(reservation);
 
         RestAssuredMockMvc.given().mockMvc(mockMvc).contentType(MediaType.APPLICATION_JSON).body(reservation)
-                          .when().put("/api/reservation/1")
+                          .when().put("/api/backoffice/reservation/1")
                           .then().statusCode(200)
                           .body("seats", is(2))
                           .body("price", is(10.0f))
@@ -177,7 +177,7 @@ class ReservationControllerTest {
     @Test
     void whenDeleteReservation_thenDeleteReservation() {
         RestAssuredMockMvc.given().mockMvc(mockMvc)
-                          .when().delete("/api/reservation/1")
+                          .when().delete("/api/public/reservation/1")
                           .then().statusCode(200);
 
         verify(service, times(1)).deleteReservationById(1L);

--- a/src/test/java/pt/ua/deti/tqs/backend/controllers/ReservationControllerTest.java
+++ b/src/test/java/pt/ua/deti/tqs/backend/controllers/ReservationControllerTest.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import pt.ua.deti.tqs.backend.controllers.backoffice.ReservationBackofficeController;
 import pt.ua.deti.tqs.backend.entities.Reservation;
 import pt.ua.deti.tqs.backend.entities.Trip;
 import pt.ua.deti.tqs.backend.entities.User;
@@ -19,7 +20,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.*;
 
-@WebMvcTest(ReservationController.class)
+@WebMvcTest(ReservationBackofficeController.class)
 class ReservationControllerTest {
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/pt/ua/deti/tqs/backend/controllers/StatsControllerTest.java
+++ b/src/test/java/pt/ua/deti/tqs/backend/controllers/StatsControllerTest.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
+import pt.ua.deti.tqs.backend.controllers.backoffice.StatsController;
 import pt.ua.deti.tqs.backend.services.StatsService;
 
 import static org.hamcrest.Matchers.is;

--- a/src/test/java/pt/ua/deti/tqs/backend/controllers/StatsControllerTest.java
+++ b/src/test/java/pt/ua/deti/tqs/backend/controllers/StatsControllerTest.java
@@ -26,7 +26,7 @@ class StatsControllerTest {
         when(service.getCacheMisses()).thenReturn(0);
 
         RestAssuredMockMvc.given().mockMvc(mockMvc)
-                          .when().get("/api/stats")
+                          .when().get("/api/backoffice/stats")
                           .then().statusCode(200)
                           .body("totalRequests", is(1))
                           .body("cacheMisses", is(0));

--- a/src/test/java/pt/ua/deti/tqs/backend/controllers/TripControllerTest.java
+++ b/src/test/java/pt/ua/deti/tqs/backend/controllers/TripControllerTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.Mockito.*;
 
-@WebMvcTest(TripBackofficeController.class)
+@WebMvcTest({TripController.class, TripBackofficeController.class})
 class TripControllerTest {
     @Autowired
     private MockMvc mvc;
@@ -42,7 +42,7 @@ class TripControllerTest {
     }
 
     @Test
-    void whenPostTrip_thenCreateTrip() throws Exception {
+    void whenPostTrip_thenCreateTrip() {
         City city1 = new City();
         city1.setId(1L);
         city1.setName("Porto");
@@ -67,7 +67,7 @@ class TripControllerTest {
         when(service.createTrip(Mockito.any())).thenReturn(trip);
 
         RestAssuredMockMvc.given().mockMvc(mvc).contentType(ContentType.JSON).body(trip)
-                          .when().post("/api/trip")
+                          .when().post("/api/backoffice/trip")
                           .then().statusCode(201)
                           .body("price", is((float) trip.getPrice()))
                           .body("bus.capacity", is(trip.getBus().getCapacity()))
@@ -114,7 +114,7 @@ class TripControllerTest {
         when(service.getTrips(Mockito.any(), Mockito.eq(null))).thenReturn(List.of(trip1, trip2));
 
         RestAssuredMockMvc.given().mockMvc(mvc)
-                          .when().get("/api/trip")
+                          .when().get("/api/public/trip")
                           .then().statusCode(200)
                           .body("[0].price", is((float) trip1.getPrice()))
                           .body("[0].bus.capacity", is(trip1.getBus().getCapacity()))
@@ -168,7 +168,8 @@ class TripControllerTest {
         when(service.getTrips(Mockito.any(), Mockito.eq(null))).thenReturn(List.of(trip1, trip2));
 
         RestAssuredMockMvc.given().mockMvc(mvc)
-                          .when().get("/api/trip?departure=1&arrival=2&departureTime=2024-03-29T00:00:00&seats=2")
+                          .when()
+                          .get("/api/public/trip?departure=1&arrival=2&departureTime=2024-03-29T00:00:00&seats=2")
                           .then().statusCode(200)
                           .body("[0].price", is((float) trip1.getPrice()))
                           .body("[0].bus.capacity", is(trip1.getBus().getCapacity()))
@@ -205,7 +206,7 @@ class TripControllerTest {
         when(service.getTrip(1L, null)).thenReturn(trip);
 
         RestAssuredMockMvc.given().mockMvc(mvc)
-                          .when().get("/api/trip/1")
+                          .when().get("/api/public/trip/1")
                           .then().statusCode(200)
                           .body("price", is((float) trip.getPrice()))
                           .body("bus.capacity", is(trip.getBus().getCapacity()))
@@ -243,7 +244,7 @@ class TripControllerTest {
         when(service.getTrip(1L, Currency.USD)).thenReturn(trip);
 
         RestAssuredMockMvc.given().mockMvc(mvc)
-                          .when().get("/api/trip/1?currency=USD")
+                          .when().get("/api/public/trip/1?currency=USD")
                           .then().statusCode(200)
                           .body("price", is((float) trip.getPrice()))
                           .body("bus.capacity", is(trip.getBus().getCapacity()))
@@ -260,7 +261,7 @@ class TripControllerTest {
         when(service.getTrip(1L, null)).thenReturn(null);
 
         RestAssuredMockMvc.given().mockMvc(mvc)
-                          .when().get("/api/trip/1")
+                          .when().get("/api/public/trip/1")
                           .then().statusCode(404);
 
         verify(service, times(1)).getTrip(1L, null);
@@ -297,7 +298,7 @@ class TripControllerTest {
         when(reservationService.getReservationsByTripId(1L, null)).thenReturn(List.of(reservation));
 
         RestAssuredMockMvc.given().mockMvc(mvc)
-                          .when().get("/api/trip/1/reservations")
+                          .when().get("/api/backoffice/trip/1/reservations")
                           .then().statusCode(200)
                           .body("[0].seats", is(1))
                           .body("[0].trip.id", is(1));
@@ -331,7 +332,7 @@ class TripControllerTest {
         when(service.updateTrip(Mockito.any())).thenReturn(trip);
 
         RestAssuredMockMvc.given().mockMvc(mvc).contentType(ContentType.JSON).body(trip)
-                          .when().put("/api/trip/1")
+                          .when().put("/api/backoffice/trip/1")
                           .then().statusCode(200)
                           .body("price", is((float) trip.getPrice()))
                           .body("bus.capacity", is(trip.getBus().getCapacity()))
@@ -346,7 +347,7 @@ class TripControllerTest {
     @Test
     void whenDeleteTrip_thenDeleteTrip() throws Exception {
         RestAssuredMockMvc.given().mockMvc(mvc)
-                          .when().delete("/api/trip/1")
+                          .when().delete("/api/backoffice/trip/1")
                           .then().statusCode(200);
 
         verify(service, times(1)).deleteTrip(1L);

--- a/src/test/java/pt/ua/deti/tqs/backend/controllers/TripControllerTest.java
+++ b/src/test/java/pt/ua/deti/tqs/backend/controllers/TripControllerTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
+import pt.ua.deti.tqs.backend.controllers.backoffice.TripBackofficeController;
 import pt.ua.deti.tqs.backend.entities.Bus;
 import pt.ua.deti.tqs.backend.entities.City;
 import pt.ua.deti.tqs.backend.entities.Reservation;
@@ -25,7 +26,7 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.Mockito.*;
 
-@WebMvcTest(TripController.class)
+@WebMvcTest(TripBackofficeController.class)
 class TripControllerTest {
     @Autowired
     private MockMvc mvc;

--- a/src/test/java/pt/ua/deti/tqs/backend/controllers/UserControllerTest.java
+++ b/src/test/java/pt/ua/deti/tqs/backend/controllers/UserControllerTest.java
@@ -43,7 +43,7 @@ class UserControllerTest {
         when(service.createUser(Mockito.any())).thenReturn(user);
 
         RestAssuredMockMvc.given().mockMvc(mockMvc).contentType(MediaType.APPLICATION_JSON).body(user)
-                          .when().post("/api/user")
+                          .when().post("/api/public/user")
                           .then().statusCode(201)
                           .body("id", is(1))
                           .body("name", is("John Doe"))
@@ -65,7 +65,7 @@ class UserControllerTest {
         when(service.getUser(1L)).thenReturn(user);
 
         RestAssuredMockMvc.given().mockMvc(mockMvc)
-                          .when().get("/api/user/1")
+                          .when().get("/api/public/user/1")
                           .then().statusCode(200)
                           .body("id", is(1))
                           .body("name", is("John Doe"))
@@ -80,7 +80,7 @@ class UserControllerTest {
         when(service.getUser(1L)).thenReturn(null);
 
         RestAssuredMockMvc.given().mockMvc(mockMvc)
-                          .when().get("/api/user/1")
+                          .when().get("/api/public/user/1")
                           .then().statusCode(404);
 
         verify(service, times(1)).getUser(1L);
@@ -99,7 +99,7 @@ class UserControllerTest {
 
         RestAssuredMockMvc.given().mockMvc(mockMvc).contentType(MediaType.APPLICATION_JSON)
                           .body("{\"email\":\"johndoe@ua.pt\",\"password\":\"password\"}")
-                          .when().post("/api/user/login")
+                          .when().post("/api/public/user/login")
                           .then().statusCode(200)
                           .body("id", is(1))
                           .body("name", is(user.getName()))
@@ -116,7 +116,7 @@ class UserControllerTest {
         when(service.loginUser("wrongEmail", "wrongPassword")).thenReturn(null);
 
         RestAssuredMockMvc.given().mockMvc(mockMvc).contentType(MediaType.APPLICATION_JSON).body(user)
-                          .when().post("/api/user/login")
+                          .when().post("/api/public/user/login")
                           .then().statusCode(401);
     }
 
@@ -136,7 +136,7 @@ class UserControllerTest {
         when(reservationService.getReservationsByUserId(1L, null)).thenReturn(List.of(reservation));
 
         RestAssuredMockMvc.given().mockMvc(mockMvc)
-                          .when().get("/api/user/1/reservations")
+                          .when().get("/api/public/user/1/reservations")
                           .then().statusCode(200)
                           .body("$", hasSize(1))
                           .body("[0].id", is(1));
@@ -156,7 +156,7 @@ class UserControllerTest {
         when(service.updateUser(Mockito.any(User.class))).then(returnsFirstArg());
 
         RestAssuredMockMvc.given().mockMvc(mockMvc).contentType(MediaType.APPLICATION_JSON).body(user)
-                          .when().put("/api/user/1")
+                          .when().put("/api/public/user/1")
                           .then().statusCode(200)
                           .body("id", is(1))
                           .body("name", is("John Doe"))
@@ -169,7 +169,7 @@ class UserControllerTest {
     @Test
     void whenDeleteUser_thenDeleteUser() {
         RestAssuredMockMvc.given().mockMvc(mockMvc)
-                          .when().delete("/api/user/1")
+                          .when().delete("/api/public/user/1")
                           .then().statusCode(200);
 
         verify(service, times(1)).deleteUser(1L);

--- a/src/test/java/pt/ua/deti/tqs/backend/integrations/BusControllerTestIT.java
+++ b/src/test/java/pt/ua/deti/tqs/backend/integrations/BusControllerTestIT.java
@@ -62,7 +62,7 @@ class BusControllerTestIT {
         bus.setCapacity(50);
 
         RestAssured.given().contentType(ContentType.JSON).body(bus)
-                   .when().post(BASE_URL + "/api/bus")
+                   .when().post(BASE_URL + "/api/backoffice/bus")
                    .then().statusCode(HttpStatus.CREATED.value())
                    .body("capacity", equalTo(bus.getCapacity()));
 
@@ -75,7 +75,7 @@ class BusControllerTestIT {
         Bus bus1 = createTestBus(50);
         Bus bus2 = createTestBus(60);
 
-        RestAssured.when().get(BASE_URL + "/api/bus")
+        RestAssured.when().get(BASE_URL + "/api/backoffice/bus")
                    .then().statusCode(HttpStatus.OK.value())
                    .body("", hasSize(2))
                    .body("capacity", hasItems(bus1.getCapacity(), bus2.getCapacity()));
@@ -85,14 +85,14 @@ class BusControllerTestIT {
     void whenGetBusById_thenStatus200() {
         Bus bus = createTestBus(50);
 
-        RestAssured.when().get(BASE_URL + "/api/bus/" + bus.getId())
+        RestAssured.when().get(BASE_URL + "/api/backoffice/bus/" + bus.getId())
                    .then().statusCode(HttpStatus.OK.value())
                    .body("capacity", equalTo(bus.getCapacity()));
     }
 
     @Test
     void whenGetBusByInvalidId_thenStatus404() {
-        RestAssured.when().get(BASE_URL + "/api/bus/999")
+        RestAssured.when().get(BASE_URL + "/api/backoffice/bus/999")
                    .then().statusCode(HttpStatus.NOT_FOUND.value());
     }
 
@@ -102,7 +102,7 @@ class BusControllerTestIT {
 
         bus.setCapacity(60);
         RestAssured.given().contentType(ContentType.JSON).body(bus)
-                   .when().put(BASE_URL + "/api/bus/" + bus.getId())
+                   .when().put(BASE_URL + "/api/backoffice/bus/" + bus.getId())
                    .then().statusCode(HttpStatus.OK.value())
                    .body("capacity", equalTo(bus.getCapacity()));
 
@@ -115,7 +115,7 @@ class BusControllerTestIT {
         Bus bus = createTestBus(50);
 
         RestAssured.given().contentType(ContentType.JSON).body(bus)
-                   .when().put(BASE_URL + "/api/bus/999")
+                   .when().put(BASE_URL + "/api/backoffice/bus/999")
                    .then().statusCode(HttpStatus.NOT_FOUND.value());
     }
 
@@ -123,7 +123,7 @@ class BusControllerTestIT {
     void whenDeleteBus_thenStatus200() {
         Bus bus = createTestBus(50);
 
-        RestAssured.when().delete(BASE_URL + "/api/bus/" + bus.getId())
+        RestAssured.when().delete(BASE_URL + "/api/backoffice/bus/" + bus.getId())
                    .then().statusCode(HttpStatus.OK.value());
 
         assertThat(repository.findById(bus.getId())).isEmpty();

--- a/src/test/java/pt/ua/deti/tqs/backend/integrations/CityControllerTestIT.java
+++ b/src/test/java/pt/ua/deti/tqs/backend/integrations/CityControllerTestIT.java
@@ -62,7 +62,7 @@ class CityControllerTestIT {
         city.setName("Aveiro");
 
         RestAssured.given().contentType(ContentType.JSON).body(city)
-                   .when().post(BASE_URL + "/api/city")
+                   .when().post(BASE_URL + "/api/backoffice/city")
                    .then().statusCode(HttpStatus.CREATED.value())
                    .body("name", equalTo(city.getName()));
 
@@ -75,7 +75,7 @@ class CityControllerTestIT {
         City city = createTestCity("Aveiro");
         City city2 = createTestCity("Porto");
 
-        RestAssured.when().get(BASE_URL + "/api/city")
+        RestAssured.when().get(BASE_URL + "/api/backoffice/city")
                    .then().statusCode(HttpStatus.OK.value())
                    .body("", hasSize(2))
                    .body("name", hasItems(city.getName(), city2.getName()));
@@ -85,7 +85,7 @@ class CityControllerTestIT {
     void whenGetCityById_thenStatus200() {
         City city = createTestCity("Aveiro");
 
-        RestAssured.when().get(BASE_URL + "/api/city/" + city.getId())
+        RestAssured.when().get(BASE_URL + "/api/backoffice/city/" + city.getId())
                    .then().statusCode(HttpStatus.OK.value())
                    .body("name", equalTo(city.getName()));
     }
@@ -95,7 +95,7 @@ class CityControllerTestIT {
         City city = createTestCity("Aveiro");
         createTestCity("Porto");
 
-        RestAssured.when().get(BASE_URL + "/api/city?name=" + city.getName())
+        RestAssured.when().get(BASE_URL + "/api/backoffice/city?name=" + city.getName())
                    .then().statusCode(HttpStatus.OK.value())
                    .body("", hasSize(1))
                    .body("name", hasItems(city.getName()));
@@ -103,13 +103,13 @@ class CityControllerTestIT {
 
     @Test
     void whenGetCityByInvalidId_thenStatus404() {
-        RestAssured.when().get(BASE_URL + "/api/city/999")
+        RestAssured.when().get(BASE_URL + "/api/backoffice/city/999")
                    .then().statusCode(HttpStatus.NOT_FOUND.value());
     }
 
     @Test
     void whenGetCityByInvalidName_thenStatus404() {
-        RestAssured.when().get(BASE_URL + "/api/city?name=aaaa")
+        RestAssured.when().get(BASE_URL + "/api/backoffice/city?name=aaaa")
                    .then().statusCode(HttpStatus.OK.value())
                    .body("", hasSize(0));
     }
@@ -120,7 +120,7 @@ class CityControllerTestIT {
 
         city.setName("Porto");
         RestAssured.given().contentType(ContentType.JSON).body(city)
-                   .when().put(BASE_URL + "/api/city/" + city.getId())
+                   .when().put(BASE_URL + "/api/backoffice/city/" + city.getId())
                    .then().statusCode(HttpStatus.OK.value()).body("name", equalTo(city.getName()));
     }
 
@@ -129,7 +129,7 @@ class CityControllerTestIT {
         City city = createTestCity("Aveiro");
 
         RestAssured.given().contentType(ContentType.JSON).body(city)
-                   .when().put(BASE_URL + "/api/city/999")
+                   .when().put(BASE_URL + "/api/backoffice/city/999")
                    .then().statusCode(HttpStatus.NOT_FOUND.value());
     }
 
@@ -137,7 +137,7 @@ class CityControllerTestIT {
     void whenDeleteCity_thenStatus200() {
         City city = createTestCity("Aveiro");
 
-        RestAssured.when().delete(BASE_URL + "/api/city/" + city.getId())
+        RestAssured.when().delete(BASE_URL + "/api/backoffice/city/" + city.getId())
                    .then().statusCode(HttpStatus.OK.value());
 
         assertThat(repository.findById(city.getId())).isEmpty();

--- a/src/test/java/pt/ua/deti/tqs/backend/integrations/ReservationControllerTestIT.java
+++ b/src/test/java/pt/ua/deti/tqs/backend/integrations/ReservationControllerTestIT.java
@@ -108,7 +108,7 @@ class ReservationControllerTestIT {
         reservation.setSeats(1);
 
         RestAssured.given().contentType(ContentType.JSON).body(reservation)
-                   .when().post(BASE_URL + "/api/reservation")
+                   .when().post(BASE_URL + "/api/public/reservation")
                    .then().statusCode(HttpStatus.CREATED.value())
                    .body("price", equalTo((float) reservation.getPrice()))
                    .body("seats", equalTo(reservation.getSeats()))
@@ -156,7 +156,7 @@ class ReservationControllerTestIT {
         reservation.setSeats(51);
 
         RestAssured.given().contentType(ContentType.JSON).body(reservation)
-                   .when().post(BASE_URL + "/api/reservation")
+                   .when().post(BASE_URL + "/api/public/reservation")
                    .then().statusCode(HttpStatus.BAD_REQUEST.value());
     }
 
@@ -165,7 +165,7 @@ class ReservationControllerTestIT {
         Reservation reservation1 = createTestReservation();
         Reservation reservation2 = createTestReservation();
 
-        RestAssured.when().get(BASE_URL + "/api/reservation")
+        RestAssured.when().get(BASE_URL + "/api/backoffice/reservation")
                    .then().statusCode(HttpStatus.OK.value())
                    .body("", hasSize(2))
                    .body("price", hasItems((float) reservation1.getPrice(), (float) reservation2.getPrice()))
@@ -191,7 +191,7 @@ class ReservationControllerTestIT {
     void whenGetReservationById_thenStatus200() {
         Reservation reservation = createTestReservation();
 
-        RestAssured.when().get(BASE_URL + "/api/reservation/" + reservation.getId())
+        RestAssured.when().get(BASE_URL + "/api/public/reservation/" + reservation.getId())
                    .then().statusCode(HttpStatus.OK.value())
                    .body("price", equalTo((float) reservation.getPrice()))
                    .body("seats", equalTo(reservation.getSeats()))
@@ -209,7 +209,7 @@ class ReservationControllerTestIT {
     void whenGetReservationByIdAndCurrencyEuro_thenStatus200() {
         Reservation reservation = createTestReservation();
 
-        RestAssured.when().get(BASE_URL + "/api/reservation/" + reservation.getId() + "?currency=EUR")
+        RestAssured.when().get(BASE_URL + "/api/public/reservation/" + reservation.getId() + "?currency=EUR")
                    .then().statusCode(HttpStatus.OK.value())
                    .body("price", equalTo((float) reservation.getPrice()))
                    .body("seats", equalTo(reservation.getSeats()))
@@ -227,7 +227,7 @@ class ReservationControllerTestIT {
     void whenGetReservationByIdAndCurrencyUsd_thenStatus200() {
         Reservation reservation = createTestReservation();
 
-        RestAssured.when().get(BASE_URL + "/api/reservation/" + reservation.getId() + "?currency=USD")
+        RestAssured.when().get(BASE_URL + "/api/public/reservation/" + reservation.getId() + "?currency=USD")
                    .then().statusCode(HttpStatus.OK.value())
                    .body("price", not(equalTo((float) reservation.getPrice())))
                    .body("seats", equalTo(reservation.getSeats()))
@@ -243,7 +243,7 @@ class ReservationControllerTestIT {
 
     @Test
     void whenGetReservationByInvalidId_thenStatus404() {
-        RestAssured.when().get(BASE_URL + "/api/reservation/999")
+        RestAssured.when().get(BASE_URL + "/api/public/reservation/999")
                    .then().statusCode(HttpStatus.NOT_FOUND.value());
     }
 
@@ -254,7 +254,7 @@ class ReservationControllerTestIT {
         reservation.setPrice(20.0);
 
         RestAssured.given().contentType(ContentType.JSON).body(reservation)
-                   .when().put(BASE_URL + "/api/reservation/" + reservation.getId())
+                   .when().put(BASE_URL + "/api/backoffice/reservation/" + reservation.getId())
                    .then().statusCode(HttpStatus.OK.value())
                    .body("price", equalTo((float) reservation.getPrice()))
                    .body("seats", equalTo(reservation.getSeats()));
@@ -269,7 +269,7 @@ class ReservationControllerTestIT {
         Reservation reservation = createTestReservation();
 
         RestAssured.given().contentType(ContentType.JSON).body(reservation)
-                   .when().put(BASE_URL + "/api/reservation/999")
+                   .when().put(BASE_URL + "/api/backoffice/reservation/999")
                    .then().statusCode(HttpStatus.NOT_FOUND.value());
     }
 
@@ -277,7 +277,7 @@ class ReservationControllerTestIT {
     void whenDeleteReservation_thenStatus200() {
         Reservation reservation = createTestReservation();
 
-        RestAssured.when().delete(BASE_URL + "/api/reservation/" + reservation.getId())
+        RestAssured.when().delete(BASE_URL + "/api/public/reservation/" + reservation.getId())
                    .then().statusCode(HttpStatus.OK.value());
 
         Reservation found = repository.findById(reservation.getId()).orElse(null);
@@ -287,7 +287,7 @@ class ReservationControllerTestIT {
     @Test
     void whenDeleteReservationWithInvalidId_thenStatus200() {
         // This assures the trip != null conditionl
-        RestAssured.when().delete(BASE_URL + "/api/reservation/999")
+        RestAssured.when().delete(BASE_URL + "/api/public/reservation/999")
                    .then().statusCode(HttpStatus.OK.value());
 
         Reservation found = repository.findById(999L).orElse(null);

--- a/src/test/java/pt/ua/deti/tqs/backend/integrations/TripControllerTestIT.java
+++ b/src/test/java/pt/ua/deti/tqs/backend/integrations/TripControllerTestIT.java
@@ -88,7 +88,7 @@ class TripControllerTestIT {
         trip.setPrice(10.0);
 
         RestAssured.given().contentType(ContentType.JSON).body(trip)
-                   .when().post(BASE_URL + "/api/trip")
+                   .when().post(BASE_URL + "/api/backoffice/trip")
                    .then().statusCode(HttpStatus.CREATED.value())
                    .body("price", equalTo((float) trip.getPrice()))
                    .body("departure.name", equalTo(trip.getDeparture().getName()))
@@ -116,7 +116,7 @@ class TripControllerTestIT {
         Trip trip1 = createTestTrip();
         Trip trip2 = createTestTrip();
 
-        RestAssured.when().get(BASE_URL + "/api/trip")
+        RestAssured.when().get(BASE_URL + "/api/public/trip")
                    .then().statusCode(HttpStatus.OK.value())
                    .body("", hasSize(2))
                    .body("price", hasItems((float) trip1.getPrice(), (float) trip2.getPrice()))
@@ -135,7 +135,7 @@ class TripControllerTestIT {
         Trip trip1 = createTestTrip();
         Trip trip2 = createTestTrip();
 
-        RestAssured.when().get(BASE_URL + "/api/trip?currency=USD")
+        RestAssured.when().get(BASE_URL + "/api/public/trip?currency=USD")
                    .then().statusCode(HttpStatus.OK.value())
                    .body("", hasSize(2))
                    .body("price", not(hasItems((float) trip1.getPrice(), (float) trip2.getPrice())));
@@ -146,7 +146,7 @@ class TripControllerTestIT {
         Trip trip1 = createTestTrip();
         Trip trip2 = createTestTrip();
 
-        RestAssured.when().get(BASE_URL + "/api/trip?currency=EUR")
+        RestAssured.when().get(BASE_URL + "/api/public/trip?currency=EUR")
                    .then().statusCode(HttpStatus.OK.value())
                    .body("", hasSize(2))
                    .body("price", hasItems((float) trip1.getPrice(), (float) trip2.getPrice()));
@@ -157,7 +157,7 @@ class TripControllerTestIT {
         Trip trip1 = createTestTrip("Aveiro", "Porto");
         createTestTrip("Porto", "Lisboa");
 
-        RestAssured.when().get(BASE_URL + "/api/trip?departure=" + trip1.getDeparture().getId())
+        RestAssured.when().get(BASE_URL + "/api/public/trip?departure=" + trip1.getDeparture().getId())
                    .then().statusCode(HttpStatus.OK.value())
                    .body("", hasSize(1))
                    .body("price", hasItems((float) trip1.getPrice()))
@@ -174,7 +174,7 @@ class TripControllerTestIT {
         createTestTrip("Aveiro", "Porto");
         createTestTrip("Porto", "Lisboa");
 
-        RestAssured.when().get(BASE_URL + "/api/trip?departure=999")
+        RestAssured.when().get(BASE_URL + "/api/public/trip?departure=999")
                    .then().statusCode(HttpStatus.OK.value())
                    .body("", hasSize(0));
     }
@@ -184,7 +184,7 @@ class TripControllerTestIT {
         Trip trip1 = createTestTrip("Aveiro", "Porto");
         createTestTrip("Porto", "Lisboa");
 
-        RestAssured.when().get(BASE_URL + "/api/trip?arrival=" + trip1.getArrival().getId())
+        RestAssured.when().get(BASE_URL + "/api/public/trip?arrival=" + trip1.getArrival().getId())
                    .then().statusCode(HttpStatus.OK.value())
                    .body("", hasSize(1))
                    .body("price", hasItems((float) trip1.getPrice()))
@@ -195,7 +195,7 @@ class TripControllerTestIT {
                          hasItems(trip1.getDepartureTime().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)))
                    .body("arrivalTime", hasItems(trip1.getArrivalTime().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)));
 
-        RestAssured.when().get(BASE_URL + "/api/trip?arrival=999")
+        RestAssured.when().get(BASE_URL + "/api/public/trip?arrival=999")
                    .then().statusCode(HttpStatus.OK.value())
                    .body("", hasSize(0));
     }
@@ -205,7 +205,7 @@ class TripControllerTestIT {
         createTestTrip("Aveiro", "Porto");
         createTestTrip("Porto", "Lisboa");
 
-        RestAssured.when().get(BASE_URL + "/api/trip?arrival=999")
+        RestAssured.when().get(BASE_URL + "/api/public/trip?arrival=999")
                    .then().statusCode(HttpStatus.OK.value())
                    .body("", hasSize(0));
     }
@@ -216,7 +216,7 @@ class TripControllerTestIT {
         createTestTrip("Porto", "Lisboa");
         createTestTrip("Aveiro", "Lisboa");
 
-        RestAssured.when().get(BASE_URL + "/api/trip?departure=" + trip1.getDeparture().getId()
+        RestAssured.when().get(BASE_URL + "/api/public/trip?departure=" + trip1.getDeparture().getId()
                                        + "&arrival=" + trip1.getArrival().getId())
                    .then().statusCode(HttpStatus.OK.value())
                    .body("", hasSize(1))
@@ -228,7 +228,7 @@ class TripControllerTestIT {
                          hasItems(trip1.getDepartureTime().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)))
                    .body("arrivalTime", hasItems(trip1.getArrivalTime().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)));
 
-        RestAssured.when().get(BASE_URL + "/api/trip?departure=999&arrival=999")
+        RestAssured.when().get(BASE_URL + "/api/public/trip?departure=999&arrival=999")
                    .then().statusCode(HttpStatus.OK.value())
                    .body("", hasSize(0));
     }
@@ -239,7 +239,7 @@ class TripControllerTestIT {
         createTestTrip("Porto", "Lisboa");
         createTestTrip("Aveiro", "Lisboa");
 
-        RestAssured.when().get(BASE_URL + "/api/trip?departure=999&arrival=999")
+        RestAssured.when().get(BASE_URL + "/api/public/trip?departure=999&arrival=999")
                    .then().statusCode(HttpStatus.OK.value())
                    .body("", hasSize(0));
     }
@@ -250,7 +250,7 @@ class TripControllerTestIT {
         createTestTrip("Porto", "Lisboa");
         createTestTrip("Aveiro", "Lisboa");
 
-        RestAssured.when().get(BASE_URL + "/api/trip?departure=" + trip1.getDeparture().getId()
+        RestAssured.when().get(BASE_URL + "/api/public/trip?departure=" + trip1.getDeparture().getId()
                                        + "&arrival=" + trip1.getArrival().getId()
                                        + "&departureTime=" + trip1.getDepartureTime().minusHours(1))
                    .then().statusCode(HttpStatus.OK.value())
@@ -270,7 +270,7 @@ class TripControllerTestIT {
         createTestTrip("Porto", "Lisboa");
         createTestTrip("Aveiro", "Lisboa");
 
-        RestAssured.when().get(BASE_URL + "/api/trip?departure=999&arrival=999&departureTime="
+        RestAssured.when().get(BASE_URL + "/api/public/trip?departure=999&arrival=999&departureTime="
                                        + LocalDateTime.now().plusHours(1))
                    .then().statusCode(HttpStatus.OK.value())
                    .body("", hasSize(0));
@@ -282,7 +282,7 @@ class TripControllerTestIT {
         createTestTrip("Porto", "Lisboa");
         createTestTrip("Aveiro", "Lisboa");
 
-        RestAssured.when().get(BASE_URL + "/api/trip?departure=" + trip1.getDeparture().getId()
+        RestAssured.when().get(BASE_URL + "/api/public/trip?departure=" + trip1.getDeparture().getId()
                                        + "&arrival=" + trip1.getArrival().getId()
                                        + "&departureTime=" + trip1.getDepartureTime().minusHours(1)
                                        + "&seats=20")
@@ -303,7 +303,7 @@ class TripControllerTestIT {
         createTestTrip("Porto", "Lisboa");
         createTestTrip("Aveiro", "Lisboa");
 
-        RestAssured.when().get(BASE_URL + "/api/trip?departure=999&arrival=999&departureTime="
+        RestAssured.when().get(BASE_URL + "/api/public/trip?departure=999&arrival=999&departureTime="
                                        + LocalDateTime.now().plusHours(1) + "&seats=999")
                    .then().statusCode(HttpStatus.OK.value())
                    .body("", hasSize(0));
@@ -313,7 +313,7 @@ class TripControllerTestIT {
     void whenGetTripById_thenStatus200() {
         Trip trip = createTestTrip();
 
-        RestAssured.when().get(BASE_URL + "/api/trip/" + trip.getId())
+        RestAssured.when().get(BASE_URL + "/api/public/trip/" + trip.getId())
                    .then().statusCode(HttpStatus.OK.value())
                    .body("price", equalTo((float) trip.getPrice()))
                    .body("departure.name", equalTo(trip.getDeparture().getName()))
@@ -328,7 +328,7 @@ class TripControllerTestIT {
     void whenGetTripByIdWithCurrencyUsd_thenStatus200() {
         Trip trip = createTestTrip();
 
-        RestAssured.when().get(BASE_URL + "/api/trip/" + trip.getId() + "?currency=USD")
+        RestAssured.when().get(BASE_URL + "/api/public/trip/" + trip.getId() + "?currency=USD")
                    .then().statusCode(HttpStatus.OK.value())
                    .body("price", not(equalTo((float) trip.getPrice())));
     }
@@ -337,14 +337,14 @@ class TripControllerTestIT {
     void whenGetTripByIdWithCurrencyEur_thenStatus200() {
         Trip trip = createTestTrip();
 
-        RestAssured.when().get(BASE_URL + "/api/trip/" + trip.getId() + "?currency=EUR")
+        RestAssured.when().get(BASE_URL + "/api/public/trip/" + trip.getId() + "?currency=EUR")
                    .then().statusCode(HttpStatus.OK.value())
                    .body("price", equalTo((float) trip.getPrice()));
     }
 
     @Test
     void whenGetTripByInvalidId_thenStatus404() {
-        RestAssured.when().get(BASE_URL + "/api/trip/999")
+        RestAssured.when().get(BASE_URL + "/api/public/trip/999")
                    .then().statusCode(HttpStatus.NOT_FOUND.value());
     }
 
@@ -352,7 +352,7 @@ class TripControllerTestIT {
     void whenGetReservationsByTripIdAndNoTripsFound_thenStatus404() {
         Trip trip = createTestTrip();
 
-        RestAssured.when().get(BASE_URL + "/api/trip/" + trip.getId() + "/reservations")
+        RestAssured.when().get(BASE_URL + "/api/public/trip/" + trip.getId() + "/reservations")
                    .then().statusCode(HttpStatus.NOT_FOUND.value());
     }
 
@@ -362,7 +362,7 @@ class TripControllerTestIT {
 
         trip.setPrice(20.0);
         RestAssured.given().contentType(ContentType.JSON).body(trip)
-                   .when().put(BASE_URL + "/api/trip/" + trip.getId())
+                   .when().put(BASE_URL + "/api/backoffice/trip/" + trip.getId())
                    .then().statusCode(HttpStatus.OK.value())
                    .body("price", equalTo((float) trip.getPrice()));
 
@@ -377,7 +377,7 @@ class TripControllerTestIT {
 
         trip.setPrice(20.0);
         RestAssured.given().contentType(ContentType.JSON).body(trip)
-                   .when().put(BASE_URL + "/api/trip/999")
+                   .when().put(BASE_URL + "/api/backoffice/trip/999")
                    .then().statusCode(HttpStatus.NOT_FOUND.value());
     }
 
@@ -385,7 +385,7 @@ class TripControllerTestIT {
     void whenDeleteTrip_thenStatus200() {
         Trip trip = createTestTrip();
 
-        RestAssured.when().delete(BASE_URL + "/api/trip/" + trip.getId())
+        RestAssured.when().delete(BASE_URL + "/api/backoffice/trip/" + trip.getId())
                    .then().statusCode(HttpStatus.OK.value());
 
         assertThat(repository.findById(trip.getId())).isEmpty();

--- a/src/test/java/pt/ua/deti/tqs/backend/integrations/UserControllerTestIT.java
+++ b/src/test/java/pt/ua/deti/tqs/backend/integrations/UserControllerTestIT.java
@@ -84,7 +84,7 @@ class UserControllerTestIT {
 
         RestAssured.given().contentType(ContentType.JSON)
                    .body("{\"username\":\"johndoe\",\"password\":\"password\",\"name\":\"John Doe\",\"email\":\"johndoe@ua.pt\"}")
-                   .when().post(BASE_URL + "/api/user")
+                   .when().post(BASE_URL + "/api/public/user")
                    .then().statusCode(HttpStatus.CREATED.value())
                    .body("username", equalTo(user.getUsername()))
                    .body("name", equalTo(user.getName()))
@@ -100,7 +100,7 @@ class UserControllerTestIT {
     void whenGetUserById_thenStatus200() {
         User user = createTestUser("John Doe", "johndoe@ua.pt", "johndoe", "password");
 
-        RestAssured.when().get(BASE_URL + "/api/user/" + user.getId())
+        RestAssured.when().get(BASE_URL + "/api/public/user/" + user.getId())
                    .then().statusCode(HttpStatus.OK.value())
                    .body("name", equalTo(user.getName()))
                    .body("email", equalTo(user.getEmail()))
@@ -109,7 +109,7 @@ class UserControllerTestIT {
 
     @Test
     void whenGetUserByInvalidId_thenStatus404() {
-        RestAssured.when().get(BASE_URL + "/api/user/999")
+        RestAssured.when().get(BASE_URL + "/api/public/user/999")
                    .then().statusCode(HttpStatus.NOT_FOUND.value());
     }
 
@@ -119,7 +119,7 @@ class UserControllerTestIT {
 
         RestAssured.given().contentType(ContentType.JSON)
                    .body("{\"email\":\"johndoe@ua.pt\",\"password\":\"password\"}")
-                   .when().post(BASE_URL + "/api/user/login")
+                   .when().post(BASE_URL + "/api/public/user/login")
                    .then().statusCode(200)
                    .body("name", is(user.getName()))
                    .body("email", is(user.getEmail()))
@@ -132,7 +132,7 @@ class UserControllerTestIT {
 
         RestAssured.given().contentType(ContentType.JSON)
                    .body("{\"email\":\"johndoe@ua.pt\",\"password\":\"password123\"}")
-                   .when().post(BASE_URL + "/api/user/login")
+                   .when().post(BASE_URL + "/api/public/user/login")
                    .then().statusCode(401);
     }
 
@@ -141,7 +141,7 @@ class UserControllerTestIT {
         User user = createTestUser("Jane Doe", "janedoe@ua.pt", "janedoe", "password");
         Reservation reservation = createTestReservation(user);
 
-        RestAssured.when().get(BASE_URL + "/api/user/" + user.getId() + "/reservations")
+        RestAssured.when().get(BASE_URL + "/api/public/user/" + user.getId() + "/reservations")
                    .then().statusCode(HttpStatus.OK.value())
                    .body("", hasSize(1))
                    .body("id", hasItems(reservation.getId().intValue()));
@@ -152,7 +152,7 @@ class UserControllerTestIT {
         User user = createTestUser("Jane Doe", "janedoe@ua.pt", "janedoe", "password");
         Reservation reservation = createTestReservation(user);
 
-        RestAssured.when().get(BASE_URL + "/api/user/" + user.getId() + "/reservations?currency=EUR")
+        RestAssured.when().get(BASE_URL + "/api/public/user/" + user.getId() + "/reservations?currency=EUR")
                    .then().statusCode(HttpStatus.OK.value())
                    .body("", hasSize(1))
                    .body("id", hasItems(reservation.getId().intValue()))
@@ -164,7 +164,7 @@ class UserControllerTestIT {
         User user = createTestUser("Jane Doe", "janedoe@ua.pt", "janedoe", "password");
         Reservation reservation = createTestReservation(user);
 
-        RestAssured.when().get(BASE_URL + "/api/user/" + user.getId() + "/reservations?currency=USD")
+        RestAssured.when().get(BASE_URL + "/api/public/user/" + user.getId() + "/reservations?currency=USD")
                    .then().statusCode(HttpStatus.OK.value())
                    .body("", hasSize(1))
                    .body("id", hasItems(reservation.getId().intValue()))
@@ -178,7 +178,7 @@ class UserControllerTestIT {
         user.setName("Jane Doe");
         RestAssured.given().contentType(ContentType.JSON)
                    .body("{\"name\":\"Jane Doe\", \"email\":\"johndoe@ua.pt\", \"username\":\"johndoe\", \"password\":\"password\"}")
-                   .when().put(BASE_URL + "/api/user/" + user.getId())
+                   .when().put(BASE_URL + "/api/public/user/" + user.getId())
                    .then().statusCode(HttpStatus.OK.value()).body("name", equalTo(user.getName()));
 
         User updated = repository.findById(user.getId()).orElse(null);
@@ -190,7 +190,7 @@ class UserControllerTestIT {
         User user = createTestUser("John Doe", "johndoe@ua.pt", "johndoe", "password");
 
         RestAssured.given().contentType(ContentType.JSON).body(user)
-                   .when().put(BASE_URL + "/api/user/999")
+                   .when().put(BASE_URL + "/api/public/user/999")
                    .then().statusCode(HttpStatus.NOT_FOUND.value());
     }
 
@@ -198,7 +198,7 @@ class UserControllerTestIT {
     void whenDeleteUser_thenStatus200() {
         User user = createTestUser("John Doe", "johndoe@ua.pt", "johndoe", "password");
 
-        RestAssured.when().delete(BASE_URL + "/api/user/" + user.getId())
+        RestAssured.when().delete(BASE_URL + "/api/public/user/" + user.getId())
                    .then().statusCode(HttpStatus.OK.value());
 
         assertThat(repository.findById(user.getId())).isEmpty();


### PR DESCRIPTION
This PR splits existing API endpoints into public and backoffice ones. This means that public endpoints now start with a `/api/public` prefix, while backend ones start with `/api/backoffice`.

## Current structure
### Backoffice
- Bus (all endpoints)
- Cache (all endpoints)
- City (all endpoints)
- Reservation
  - Get all
  - Update
- Trip
  - Create
  - Update
  - Delete

### Public
- Reservation
  - Create
  - Get one
  - Delete
- Trip
  - Get all
  - Get one
- User (all endpoints)